### PR TITLE
Fixes for wasm version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,13 @@ dependencies = [
  "dotenv",
  "eframe",
  "egui-notify",
+ "ehttp",
+ "poll-promise",
  "reqwest",
  "serde",
+ "serde_json",
  "tokio",
+ "tracing",
  "tracing-subscriber",
  "tracing-wasm",
 ]
@@ -197,6 +201,12 @@ checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clipboard-win"
@@ -546,6 +556,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ehttp"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b69a6f9168b96c0ae04763bec27a8b06b34343c334dd2703a4ec21f0f5e110"
+dependencies = [
+ "js-sys",
+ "ureq",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "emath"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +630,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1495,6 +1528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "poll-promise"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260817b339544e5b23d4bb66d4522d89dd64af88d16b6dcd7b2a2409ee2e095d"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1608,6 +1650,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1673,18 @@ dependencies = [
  "base64",
  "bitflags",
  "serde",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1663,6 +1732,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sctk-adwaita"
@@ -1853,6 +1932,18 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str-buf"
@@ -2134,6 +2225,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
+dependencies = [
+ "base64",
+ "chunked_transfer",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,6 +2481,25 @@ dependencies = [
  "web-sys",
  "widestring",
  "winapi",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ rust-version = "1.60"
 
 [dependencies]
 eframe = { version = "0.19.0", features = ["persistence"] }
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-tokio = { version = "1.20.1", features = ["full"] }
 dotenv = "0.15.0"
 egui-notify = "0.3.0"
 serde = { version = "1", features = ["derive"] } # You only need this if you want app persistence
+tracing = "0.1.36"
+ehttp = "0.2.0"
+poll-promise = "0.1.0"
+serde_json = "1.0.85"
 
 # native:
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -24,7 +26,6 @@ tracing-subscriber = "0.3"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
 tracing-wasm = "0.2"
-
 
 [profile.release]
 opt-level = 2 # fast and small wasm

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,12 @@ pub struct TemplateApp {
     closable: bool,
     duration: f32,
     mention: bool,
-    
+
+    #[serde(skip)]
+    insult_promise: Option<poll_promise::Promise<String>>,
+    #[serde(skip)]
+    insult_send_promise: Option<poll_promise::Promise<()>>,
+
     #[serde(skip)]
     toasts: Toasts,
 }
@@ -27,6 +32,9 @@ impl Default for TemplateApp {
             closable: true,
             duration: 3.5,
             mention: true,
+
+            insult_promise: None,
+            insult_send_promise: None,
         }
     }
 }
@@ -78,8 +86,8 @@ impl eframe::App for TemplateApp {
 
             ui.label("Hello and welcome to version 4 of the bully luna program!");
             ui.label(
-            "You can randomly generate an insult or write your own below to be sent to luna!",
-        );
+                "You can randomly generate an insult or write your own below to be sent to luna!",
+            );
 
             ui.separator();
             ui.horizontal(|ui| {
@@ -97,15 +105,38 @@ impl eframe::App for TemplateApp {
             ui.horizontal(|ui| {
                 let generate_button = ui.button("Generate an insult");
                 if generate_button.clicked() {
-                    self.insult = get_insult();
-                    cb(self.toasts.success("Generation Successful!")); //Sends a success toast
+                    self.insult_promise = Some(get_insult());
+                }
+
+                if let Some(promise) = &mut self.insult_promise {
+                    match promise.ready() {
+                        Some(insult) => {
+                            cb(self.toasts.success("Generation Successful!")); //Sends a success toast
+                            self.insult = insult.clone();
+                            self.insult_promise = None;
+                        }
+                        None => {
+                            ui.spinner();
+                        }
+                    }
                 }
 
                 let send_button = ui.button("Send message to luna");
                 if send_button.clicked() {
-                    send_message(&self.insult, self.mention);
-                    cb(self.toasts.success("Message Sent!"));
-                    self.insult = "".to_string();
+                    self.insult_send_promise = Some(send_message(&self.insult, self.mention));
+                }
+
+                if let Some(promise) = &mut self.insult_send_promise {
+                    match promise.ready() {
+                        Some(()) => {
+                            cb(self.toasts.success("Message Sent!"));
+                            self.insult = "".to_string();
+                            self.insult_send_promise = None;
+                        }
+                        None => {
+                            ui.spinner();
+                        }
+                    }
                 }
 
                 ui.checkbox(&mut self.mention, "Mention luna?")

--- a/src/app/api_handler.rs
+++ b/src/app/api_handler.rs
@@ -3,35 +3,47 @@
 #![allow(unused_must_use)]
 use std::collections::HashMap;
 
-pub fn get_insult() -> String {
-    //View more details on how this works here (https://www.reddit.com/r/learnrust/comments/wz9flc/how_to_get_request_to_return_as_a_string/)
-    let x = reqwest::blocking::get("https://insult.mattbas.org/api/insult")
-        .expect("Get failed")
-        .text()
-        .expect("Couldn't get response body");
-    return x;
+pub fn get_insult() -> poll_promise::Promise<String> {
+    let (sender, promise) = poll_promise::Promise::new();
+    ehttp::fetch(
+        ehttp::Request::get("https://insult.mattbas.org/api/insult"),
+        // ehttp::Request::get("https://wttr.in"),
+        move |response| {
+            let response = response.expect("Request failed");
+            let text = response
+                .text()
+                .expect("Could not get response body")
+                .to_string();
+            sender.send(text);
+        },
+    );
+    promise
 }
 
-#[tokio::main]
-pub async fn send_message(msg: &str, mention: bool) {
+pub fn send_message(msg: &str, mention: bool) -> poll_promise::Promise<()> {
     let WEBHOOK_URL = "https://canary.discord.com/api/webhooks/1014613740139839509/sdl_Q0YDa3Nwn9JMsyPAHwWB2AjGHz-cupexxVHYjWbmDL6MO9D3FUpCGAs65EywYnEM".to_string();
     let IMAGE_URL = "https://cdn.discordapp.com/avatars/892723824297119754/fdd67fef581729a0224f7bf9e8a52d3b.png?size=1024".to_string();
     let DISCORD_ID = " <@747638440404713582>".to_string();
 
     let mut message = msg.to_owned();
-    if mention == true {
+    if mention {
         message = message + &DISCORD_ID;
     }
     let message = message.as_str();
 
     let mut request_body = HashMap::new();
+
     request_body.insert("content", message);
     request_body.insert("username", "Developer Build");
     request_body.insert("avatar_url", &IMAGE_URL);
 
-    reqwest::Client::new()
-        .post(&WEBHOOK_URL)
-        .json(&request_body)
-        .send()
-        .await;
+    let json = serde_json::to_vec(&request_body).expect("Failed to generate request json body");
+
+    let request = ehttp::Request::post(&WEBHOOK_URL, json);
+    let (sender, promise) = poll_promise::Promise::new();
+    ehttp::fetch(request, move |response| {
+        tracing::info!("Discord api response: {:?}", response);
+        sender.send(());
+    });
+    promise
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
     eframe::start_web(
         "the_canvas_id", // hardcode it
         web_options,
-        Box::new(|cc| Box::new(eframe_template::TemplateApp::new(cc))),
+        Box::new(|cc| Box::new(bully_luna_v4::TemplateApp::new(cc))),
     )
     .expect("failed to start eframe");
 }


### PR DESCRIPTION
Some explanations:
The build errors in your version originate from the `socket2` crate. This crate does not support compilation to WASM.
By default, `tokio` disables the `socket2` crate, but it was re-enabled due to `features = "full"`. Disabling some of `tokios` features fixed this compiler error, however, I was not able to get the blocking feature of `reqwest` working.

What about pure async?
Well, AFAIK async requires blocking at some point, aka an async executor. My first attempt at using `tokio` for this failed as this somehow always used some background logic which was depending on threads. And threads don't work at all in WASM for now (they may do in the future, however).

It would have been an option to use some async executor that explicitly supported WASM — however, these mostly seemed incapable to return values upon completion.

After all this, I decided to use `ehttp` instead of `reqwest` and `poll_promise` instead of `tokio`.

This allows the app to be fully WASM compatible and non-blocking.
`ehttp`s `fetch` function will execute a provided closure once the request finishes (or in case of a timeout or some other error).
`poll_promise` is build around a sender and a receiver, which allows passing a value across threads. (Yes, threads don't work in WASM, but JavaScript's “promises” are half thread half async code. They are similar to rust's async, but not lazy executed.)

Now the workflow is to store the promise in the app's struct to preserve the state.
Every time the UI is redrawn, it is checked if the promise is ready. If it is ready, it will return `Some` with the result. If it is not ready, it just returns `None`.

There are still some cave-eats:
 - When I was testing the code, I had the insult API time-out quite often, which in the current implementation results in a crash. (due `expect(…)`, can be fixed easily).
 - The discord API request failed due to CORS. This is a problem I already had with another project. There I was able to fix it by modifying my server code, something that you probably won't be able to do with discord. I'm not sure if this happens only to me because of some browser configuration, or if the CORS check (done by the browser) can be disabled.
 - The error you posted in discord looks like some malformed request. I did my best to translate the code from `reqwest` to `ehttp` but I may have missed something there.

I'm marking this PR as draft, as there are still some things that can and should be fixed.
Feel free to comment and ask further questions, I am writing this here as did not want to send this wall of text to the questions channel in discord. ;)